### PR TITLE
support email addresses using all currently valid top-level domains,  2-24 characters in length

### DIFF
--- a/ecvi2.xsd
+++ b/ecvi2.xsd
@@ -860,7 +860,7 @@
             <xs:documentation>Optional email address following simplified standard email address pattern.</xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}"/>
+            <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,24}"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
Use of generic top level domains longer than 4 characters is possible for some email addresses.  For example, .auction is 7 characters and would not be valid with the current email address validation pattern.  Proposing expansion to 24 characters to accommodate the longest currently valid domains according to IANA  [http://data.iana.org/TLD/tlds-alpha-by-domain.txt](url).