### PR TITLE
Adds clarification around Voided and ReplacesCviNumber attributes

### DIFF
--- a/ecvi2.xsd
+++ b/ecvi2.xsd
@@ -39,6 +39,7 @@
         07/09/2020: Added TestName attribute. #44
         08/13/2020: Added choice element requiring one or more Animal, GroupLot or Product.  #54
         08/13/2020: Updated annotations in several places. #51, #52, #53
+        TBD: Clarifcation around usage of Voided and ReplacesCviNumber attributes
         </xs:documentation>
     </xs:annotation>
     <xs:annotation>
@@ -87,14 +88,23 @@
             <xs:attribute name="ExpirationDate" type="xs:date" use="required"/>
             <xs:attribute name="ShipmentDate" type="xs:date" use="optional"/>
             <xs:attribute name="EntryPermitNumber" type="xs:string" use="optional"/>
-            <xs:attribute name="ReplacesCviNumber" type="nonNullString" use="optional"/>
-            <xs:attribute name="Voided" type="xs:boolean" default="false" use="optional">
-                <xs:annotation>
-                    <xs:documentation>True indicates that the CVI named in ReplacesCviNumber has been revoked.
-                                      Voided certificates must include a copy of the human-readable--PDF, etc--
-                                      version of the certificate clearly marked as void.</xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
+            <xs:choice  minOccurs="0" maxOccurs="1">
+                <xs:attribute name="ReplacesCviNumber" type="nonNullString" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>If present, this value is the number of the CVI that is superceded by this
+                                          CVI. The presense of this value also implies that the superceded CVI must
+                                          be considered void, regardless of whether or not there was an explicit
+                                          void request preceding this CVI message.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="Voided" type="xs:boolean" default="false" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>True indicates that this CVI has been revoked.
+                                          Voided certificates must include a copy of the human-readable--PDF, etc--
+                                          version of the certificate clearly marked as void.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:choice>
         </xs:complexType>
     </xs:element>
     <!-- END Document Element -->


### PR DESCRIPTION
Following up on a discussion on April 5, here are suggested updates to the schema to provide clarification on how the `Voided` and `ReplacesCviNumber` attributes are to be used.

A few key concepts are captured in this change:

- `Voided` and `ReplacesCviNumber` cannot be used together; these should be viewed as two separate logical operations; the certificate can be voided or it can replace/amend a previous CVI, but it can't do both
- `Voided`, if present, applies to the CVI in which it's contained
- `ReplacesCviNumber`, if present, communicates that the referenced CVI is no longer valid, and that the CVI which references it is meant to replace it