### PR TITLE
Add InternationalAIN as a valid option for animal tag

### DIFF
--- a/ecvi2.xsd
+++ b/ecvi2.xsd
@@ -1038,6 +1038,7 @@
             <xs:sequence minOccurs="1" maxOccurs="unbounded">
                 <xs:choice>
                     <xs:element ref="AIN"/>
+					<xs:element ref="InternationalAIN"/>
                     <xs:element ref="MfrRFID"/>
                     <xs:element ref="NUES9"/>
                     <xs:element ref="NUES8"/>

--- a/ecvi2.xsd
+++ b/ecvi2.xsd
@@ -1038,7 +1038,7 @@
             <xs:sequence minOccurs="1" maxOccurs="unbounded">
                 <xs:choice>
                     <xs:element ref="AIN"/>
-					<xs:element ref="InternationalAIN"/>
+                    <xs:element ref="InternationalAIN"/>
                     <xs:element ref="MfrRFID"/>
                     <xs:element ref="NUES9"/>
                     <xs:element ref="NUES8"/>


### PR DESCRIPTION
In the current (v3.0) standard, we say we support international AINs through the use of the `InternationalAIN` element. However, that element is not in the list of child options for the `AninmalTags` element. Therefore, any CVI attempting to make use of the new `InternationalAIN` element will be considered invalid.

The change in this PR adds `InternationalAIN` to the list of valid animal tag options. A fake CVI implementing `InternationalAIN` (along with a few other v3.0 features) can be found here for testing this change: https://gist.github.com/MichaelJRussell/0ebd2c8227c9dbd358b756312be4972b